### PR TITLE
[nit] propagate issuance errors from the IssuerBackend

### DIFF
--- a/issuer-backend/IssuerBackend/Program.cs
+++ b/issuer-backend/IssuerBackend/Program.cs
@@ -61,9 +61,10 @@ app.MapPost("/api/issue", async (string email, string name, FoodClass foodType, 
                 SendNotification = true
             });
         }
-        catch
+        catch (Exception ex)
         {
-            throw new Exception("Error issuing credential");
+            Console.WriteLine("Error: " + ex.Message);
+            throw new Exception("Error issuing credential: " + ex.Message);
         }
 
         return new IssueResponse()

--- a/src/layouts/LandingPage/IssueModal/index.tsx
+++ b/src/layouts/LandingPage/IssueModal/index.tsx
@@ -65,7 +65,16 @@ const handleIssueCredential = async (
     const response = await fetch(url, { method: "POST" });
     const wnd: any = window;
     wnd.blah = response;
-    return await response.json();
+
+    // We expect a response in the form of { success: boolean, error?: string }
+    // If there was an error here, throw it so that the React mutation can handle it
+    let json = await response.json();
+    if (!json.success) {
+        throw new Error(json.error)
+    }
+    else {
+        return json;
+    }
 };
 
 export const IssueModal = () => {
@@ -276,6 +285,14 @@ export const IssueModal = () => {
                                                 Receive your credential
                                             </div>
                                         </button>
+                                        {isError && (
+                                            <div className="group flex h-full w-full flex-row items-center space-x-6 rounded-lg
+                                            px-4 py-3 bg-red-100">
+                                                <span className="text-red-500">
+                                                    {error instanceof Error ? error.message : "Error"}
+                                                </span>
+                                            </div>
+                                        )}
                                     </div>
                                 </div>
                             </motion.div>


### PR DESCRIPTION
Hi friends!  @michaeldboyd showed me OkeyDoke recently - it's cool!  I toyed with it over the weekend and have a quick nit/fix for you to help other tinkerers.

**tl;dr:** when IssuerBackend returns an error at `/api/issue`, the frontend ignores it.  In this fix, the frontend checks for errors and displays the error message for useful debugging.

### Tests
1. Induce issuance error: set my Trinsic authtoken to an invalid value (left it as "REPLACE ME")
2. Run IssuerBackend locally/point frontend to it
3. Issue credential, expect error to show

*Before* (swallows the error, pretends I got a credential): 
![image](https://user-images.githubusercontent.com/25647843/236724297-69c136ee-dcdb-45d1-acf2-8cf6c224f469.png)

*After* (shows the expected error):
![image](https://user-images.githubusercontent.com/25647843/236724468-8bbbf880-e96a-4508-8cfe-fbe1aceefff8.png)